### PR TITLE
Checking for Git binary

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -2,8 +2,10 @@
 
 VERSION=1.0.5
 if test -e .git; then
-    VERSION=$(git describe --always --tags --dirty | \
-        sed -e 's/^v//' -e 's/-[0-9]*-g/-g/' | tr -d '\n')
+    if hash git 2>/dev/null; then
+        VERSION=$(git describe --always --tags --dirty | \
+            sed -e 's/^v//' -e 's/-[0-9]*-g/-g/' | tr -d '\n')
+    fi
 fi
 
 if [ -e .naemon.official ]; then


### PR DESCRIPTION
In some build systems, git is not present unless defined as a build
dependency. However the .git directory may still be copied in along with
the source. This change will still allow the required behavior in case
.git is present but the Git binary is not.
